### PR TITLE
Specify the exact version of wasm_bindgen in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ path = "src/lib.rs"
 crate-type =["cdylib"]
 
 [dependencies]
-wasm-bindgen = "0.2.50"
+wasm-bindgen = "=0.2.61"
 ```
 
 #### Write Rust code


### PR DESCRIPTION
Alleviates this error message
```
ErrorMessage { msg: "no ssvm mapping for bindgen 0.2.63" }
```