### PR TITLE
Force workflow to rebuild ssvm-napi and test wasm-learning

### DIFF
--- a/.github/actions/build-from-source/action.yml
+++ b/.github/actions/build-from-source/action.yml
@@ -5,6 +5,8 @@ inputs:
     default: 'clang'
   cxx:
     default: 'clang++'
+  path:
+    default: '.'
 
 runs:
   using: 'composite'
@@ -14,4 +16,4 @@ runs:
       CC: ${{ inputs.cc }}
       CXX: ${{ inputs.cxx }}
     run: |
-      JOBS=max npm install --build-from-source . --unsafe-perm
+      JOBS=max npm install --build-from-source --unsafe-perm ${{ inputs.path }}

--- a/.github/actions/build-from-source/action.yml
+++ b/.github/actions/build-from-source/action.yml
@@ -1,0 +1,17 @@
+name: Build SSVM-napi
+
+inputs:
+  cc:
+    default: 'clang'
+  cxx:
+    default: 'clang++'
+
+runs:
+  using: 'composite'
+  steps:
+  - shell: bash
+    env:
+      CC: ${{ inputs.cc }}
+      CXX: ${{ inputs.cxx }}
+    run: |
+      JOBS=max npm install --build-from-source . --unsafe-perm

--- a/.github/workflows/external-test.yml
+++ b/.github/workflows/external-test.yml
@@ -1,0 +1,67 @@
+name: External Test
+
+on:
+  push:
+    branches:
+      - '**/test*'
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  test_wasm_learning:
+    runs-on: ubuntu-20.04
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x]
+        ssvm-options: ['']
+
+    steps:
+    # MAGIC: Checkout wasm-learning at $GITHUB_WORKSPACE so that node
+    #        module search will find 'ssvm' from inside the testdirs.
+    - name: Checkout wasm-learning
+      uses: actions/checkout@v2
+      with:
+        repository: second-state/wasm-learning
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Checkout SSVM-napi
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        path: ssvm-napi
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get install llvm-dev liblld-10-dev libboost-all-dev
+        npm i -g ssvmup
+
+    - name: Build and install SSVM-napi
+      uses: './ssvm-napi/.github/actions/build-from-source'
+      with:
+        path: './ssvm-napi'
+
+    - name: Test functions ${{ matrix.ssvm-options }}
+      run: |
+        ssvmup build ${{ matrix.ssvm-options }}
+        node node/app.js
+        ssvmup clean
+      working-directory: nodejs/functions
+
+    - name: Test JSON IO ${{ matrix.ssvm-options }}
+      run: |
+        ssvmup build ${{ matrix.ssvm-options }}
+        node node/app.js
+        ssvmup clean
+      working-directory: nodejs/json_io
+
+    - name: Test WASI ${{ matrix.ssvm-options }}
+      run: |
+        ssvmup build ${{ matrix.ssvm-options }}
+        node node/app.js
+        ssvmup clean
+      working-directory: nodejs/wasi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,17 +1,26 @@
-name: build
+name: Main Workflow
 
 on:
   push:
     branches:
       - master
-      - '*/test*'
+      - '**/test*'
   pull_request:
     branches:
       - master
 
 jobs:
-  build_test_gcc:
+  build_and_test:
     runs-on: ubuntu-20.04
+
+    strategy:
+      matrix:
+        cc: ['clang', 'gcc']
+        include:
+          - cc: 'clang'
+            cxx: 'clang++'
+          - cc: 'gcc'
+            cxx: 'g++'
 
     steps:
     - uses: actions/checkout@v2
@@ -22,30 +31,12 @@ jobs:
       run: |
         sudo apt-get install llvm-dev liblld-10-dev libboost-all-dev
 
-    - name: Build SSVM-napi using gcc
-      run: |
-        JOBS=max npm install --fallback-to-build --update-binary . --unsafe-perm
-
-    - name: Test SSVM-napi built with gcc
-      run: |
-        JOBS=max npm test
-
-  build_test_clang:
-    runs-on: ubuntu-20.04
-
-    steps:
-    - uses: actions/checkout@v2
+    - name: Build SSVM-napi with ${{ matrix.cc }}
+      uses: './.github/actions/build-from-source'
       with:
-        submodules: recursive
+        cc: ${{ matrix.cc }}
+        cxx: ${{ matrix.cxx }}
 
-    - name: Install dependencies
-      run: |
-        sudo apt-get install llvm-dev liblld-10-dev libboost-all-dev
-
-    - name: Build SSVM-napi using clang
-      run: |
-        JOBS=max npm install --fallback-to-build --update-binary . --unsafe-perm
-
-    - name: Test SSVM-napi built with clang
+    - name: Test SSVM-napi built with ${{ matrix.cc }}
       run: |
         JOBS=max npm test


### PR DESCRIPTION
### Note
- Supposedly blocked by #55
- Forked from `0.4.16` with two duplicate commits 2ef75f7 and a18be1a from #54 

### What's in this PR
- Force workflow to `--build-from-source` (yeah it didn't really build on every PRs)
- Split build-from-source to an action for reuse by other workflow
- Run some basic tests in [wasm-learning](https://github.com/second-state/wasm-learning/) for release tags (and test-related branches of course)
